### PR TITLE
add fix for Capybara error

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 ENV["SINATRA_ENV"] = "test"
 require_relative '../config/environment.rb'
 require 'rack/test'
+require 'capybara'
+require 'capybara/dsl'
+require 'capybara/rspec'
 
 RSpec.configure do |config|
   config.include Capybara::DSL


### PR DESCRIPTION
Students were getting the following error when running tests: Uninitialized constant Capybara::DSL. 

Fix: Added required lines to spec_helper